### PR TITLE
Add NVD and CVE.org references to CYRISMA disclosures

### DIFF
--- a/Disclosures/2025/PL-2025-04231/README.md
+++ b/Disclosures/2025/PL-2025-04231/README.md
@@ -32,6 +32,8 @@ Fixed in CYRISMA Sensor version 2.5.
 - July 7, 2025 (Public Disclosure)
 
 ## References
+- https://nvd.nist.gov/vuln/detail/CVE-2025-57624
+- https://www.cve.org/cverecord?id=CVE-2025-57624
 - https://www.cyrisma.com/
 - https://msry1.gitbook.io/thegoldenrecord/blog/vulnerability-and-bug-disclosures/cyrsma-sensor-version-less-than-2.5
 - https://www.packetlabs.net/posts/cyrisma-sensor-version-444/

--- a/Disclosures/2025/PL-2025-04232/README.md
+++ b/Disclosures/2025/PL-2025-04232/README.md
@@ -32,6 +32,8 @@ TBD
 - July 7, 2025 (Public Disclosure)
 
 ## References
+- https://nvd.nist.gov/vuln/detail/CVE-2025-57625
+- https://www.cve.org/cverecord?id=CVE-2025-57625
 - https://www.cyrisma.com/
 - https://msry1.gitbook.io/thegoldenrecord/blog/vulnerability-and-bug-disclosures/cyrsma-sensor-version-less-than-2.5
 - https://www.packetlabs.net/posts/cyrisma-sensor-version-444/


### PR DESCRIPTION
## Summary
- Add NVD and CVE.org reference links to PL-2025-04231 (CVE-2025-57624) and PL-2025-04232 (CVE-2025-57625)

## Checklist
- [x] Disclosure README follows template section order
- [x] No sensitive files included
- [x] NVD and CVE.org links verified

## References
- https://nvd.nist.gov/vuln/detail/CVE-2025-57624
- https://nvd.nist.gov/vuln/detail/CVE-2025-57625
- https://www.cve.org/cverecord?id=CVE-2025-57624
- https://www.cve.org/cverecord?id=CVE-2025-57625